### PR TITLE
Allow STA with no PMF support

### DIFF
--- a/components/ocs_net/ap_network.cpp
+++ b/components/ocs_net/ap_network.cpp
@@ -55,7 +55,6 @@ ApNetwork::ApNetwork(INetworkHandler& handler, const Params& params)
     wifi_config.ap.channel = params_.channel;
     wifi_config.ap.max_connection = params_.max_connection;
     wifi_config.ap.authmode = WIFI_AUTH_WPA2_PSK;
-    wifi_config.ap.pmf_cfg.required = true;
 
     ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_AP, &wifi_config));
 }


### PR DESCRIPTION
There are a lot of IoT devices, e.g. old RPi [1], that don't support PMF [2], as a result when PMF is required, they won't be able to connect to ESP32 AP. See also ESP-IDF notes [3] about PMF usage in ESP32.

1. https://dokuwiki.alu4u.com/doku.php?id=stellar-wireless-wpa3-sae-raspberry-pi
2. https://en.wikipedia.org/wiki/IEEE_802.11w-2009
3. https://docs.espressif.com/projects/esp-idf/en/v5.4/esp32/api-guides/wifi-security.html#protected-management-frames-pmf